### PR TITLE
Mean Aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Once you have these dependencies you should be able to shrink any Bloom Model by
 | ```--hidden_downsampling_rate```  | Downsampling rate of the hidden dimension|
 | ```--layer_downsampling_rate```  | Downsampling rate of the attention blocks|
 | ```--aggregation_strategy```  | Aggregation strategy of the weights matrices - must be in [`first` `last`, `mean`]|
-| ```--layer_selection_strategy```  | Layer selection strategy of the attention layers - must be in [`first` `last`, `step`]|
+| ```--layer_selection_strategy```  | Layer selection strategy of the attention layers - must be in [`first` `last`, `step`, `mean`]|
 | ```--push_to_hub```  | Flag enabling pushing the shrinked the model on the Hub. It will push the model under the `bigscience` organization with the name `output_model_name` |
 
 Then run:

--- a/downsample_model.py
+++ b/downsample_model.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     parser.add_argument('--hidden_downsampling_rate', type=float, default=0.5, help='Downsampling rate for the hidden layers')
     parser.add_argument('--layer_downsampling_rate', type=float, default=0.5, help='Downsampling rate for the layers')
     parser.add_argument('--aggregation_strategy', type=str, default="mean", help='Aggregation strategy for the weights matrices', choices=["mean", "first", "last"])
-    parser.add_argument('--layer_selection_strategy', type=str, default="step", help='Layer selection strategy', choices=["first", "last", "step"])
+    parser.add_argument('--layer_selection_strategy', type=str, default="mean", help='Layer selection strategy', choices=["first", "last", "step", "mean"])
     parser.add_argument('--push_to_hub', action='store_true', help='Push the model to the Hub')
     args = parser.parse_args()
     main(args)

--- a/tests/test_downsampling.py
+++ b/tests/test_downsampling.py
@@ -23,10 +23,12 @@ class BloomShrinkingTest(unittest.TestCase):
         expected_first = {"h.0":"h.0", "h.1":"h.1", "h.2":"h.2"}
         expected_last = {"h.3":"h.0", "h.4":"h.1", "h.5":"h.2"}
         expected_step = {"h.0":"h.0", "h.2":"h.1", "h.4":"h.2"}
+        expected_mean = {('h.0', 'h.1'): 'h.0', ('h.2', 'h.3'): 'h.1', ('h.4', 'h.5'): 'h.2'}
         strategies_to_test = {
             "first":expected_first,
             "last":expected_last,
             "step":expected_step,
+            "mean":expected_mean,
         }
         for strategy in strategies_to_test.keys():
             self.assertDictEqual(select_layers_from_strategy(strategy, self.n_layers, self.depth_downsampling_rate), strategies_to_test[strategy])


### PR DESCRIPTION
Now the script supports mean aggregation across layers. Basically what happens is:

- before shrinking the width of the model, select n layers
- average those layers instead of selection the n-th layer (step selection strategy)

This applies only for attention blocks. 
Example: Let us assume we have 32 layers. We want to shrink the number of layers by 2. We would end up by averaging the layers:
0 and 1 => assigned to layer 0  - 2 and 3 => assigned to layer 1 -  ... - 30 and 31 => assigned to layer 15 

You just have to specify: `layer_selection_strategy` to `mean`